### PR TITLE
Tweak CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,9 +31,6 @@ jobs:
   build-nostd:
     runs-on: ubuntu-latest
 
-    needs:
-    - formatting
-
     steps:
     - uses: actions/checkout@v2
 
@@ -47,11 +44,24 @@ jobs:
     - name: Build no_std
       run: cargo build --verbose --target thumbv7em-none-eabihf -Z avoid-dev-deps
 
-  build:
+  build-msrv:
     runs-on: ubuntu-latest
 
-    needs:
-    - formatting
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: 1.61
+        target: thumbv7em-none-eabihf
+        override: true
+
+    - name: Build with MSRV
+      run: cargo build
+
+  build:
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -64,9 +74,6 @@ jobs:
 
           - name: nightly
             rust: nightly
-
-          - name: msrv
-            rust: 1.61.0
 
     steps:
     - uses: actions/checkout@v2
@@ -132,7 +139,7 @@ jobs:
         toolchain: stable
         target: thumbv7em-none-eabihf
         override: true
-    
+
     - name: Check doc links
       run: |
         cargo doc --color=never &> ./out

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
 
-  formatting:
+  linting:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,10 +23,13 @@ jobs:
         toolchain: stable
         target: thumbv7em-none-eabihf
         override: true
-        components: rustfmt
+        components: rustfmt, clippy
 
     - name: Check formatting
       run: cargo fmt --all -- --check
+
+    - name: Run clippy
+      run: cargo clippy -- -D warnings
 
   build-nostd:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Unreleased
+==========
+
+ - [#174] Implement `Default` for `TextBoxStyleBuilder`
+
+[#174]: https://github.com/embedded-graphics/embedded-text/pull/174
+
 0.7.3 (2025-10-10)
 ==================
 

--- a/src/style/builder.rs
+++ b/src/style/builder.rs
@@ -15,6 +15,13 @@ pub struct TextBoxStyleBuilder {
     trailing_spaces: Option<bool>,
 }
 
+impl Default for TextBoxStyleBuilder {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TextBoxStyleBuilder {
     /// Create a new builder object.
     #[inline]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,7 +22,7 @@ pub fn str_width_and_left_offset(renderer: &impl TextRenderer, s: &str) -> (u32,
     let tm = renderer.measure_string(s, Point::zero(), Baseline::Top);
     (
         tm.next_position.x as u32,
-        tm.bounding_box.top_left.x.min(0).abs() as u32,
+        tm.bounding_box.top_left.x.min(0).unsigned_abs(),
     )
 }
 


### PR DESCRIPTION
Don't block everything on the format check. Build MSRV separately (as simulator now needs 1.63 at least), run `clippy`.